### PR TITLE
[#6] Jwt 토큰 방식을 활용한 로그인 구현

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -36,6 +36,10 @@ dependencies {
     runtimeOnly("mysql:mysql-connector-java")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
     testImplementation("org.springframework.security:spring-security-test")
+
+    implementation(group = "io.jsonwebtoken", name = "jjwt-api", version = "0.11.2")
+    runtimeOnly(group = "io.jsonwebtoken", name = "jjwt-impl", version = "0.11.2")
+    runtimeOnly(group = "io.jsonwebtoken", name = "jjwt-jackson", version = "0.11.2")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/kotlin/delivery/auth/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/kotlin/delivery/auth/jwt/JwtTokenProvider.kt
@@ -1,0 +1,34 @@
+package com.kotlin.delivery.auth.jwt
+
+import com.kotlin.delivery.common.property.JwtProperty
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import io.jsonwebtoken.io.Decoders
+import io.jsonwebtoken.security.Keys
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import java.security.Key
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.util.Date
+
+@Component
+class JwtTokenProvider(private val prop: JwtProperty) {
+
+    val key: Key = Keys.hmacShaKeyFor(Decoders.BASE64.decode(prop.secretKey))
+
+    fun generateToken(authentication: Authentication): String {
+        val authorities = authentication.authorities.joinToString()
+
+        val expiration = Date.from(
+            LocalDateTime.now().plusMinutes(prop.duration).atZone(ZoneId.systemDefault()).toInstant()
+        )
+
+        return Jwts.builder()
+            .setSubject(authentication.name)
+            .claim("auth", authorities)
+            .setExpiration(expiration)
+            .signWith(key, SignatureAlgorithm.HS512)
+            .compact()
+    }
+}

--- a/src/main/kotlin/com/kotlin/delivery/common/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/kotlin/delivery/common/config/SecurityConfig.kt
@@ -14,7 +14,12 @@ import org.springframework.security.crypto.password.PasswordEncoder
 class SecurityConfig : WebSecurityConfigurerAdapter() {
 
     override fun configure(http: HttpSecurity) {
-        http.csrf().disable()
+        http
+            .csrf().disable()
+            .authorizeRequests()
+            .antMatchers("/members/common/sign-up").permitAll()
+            .antMatchers("/members/common/login").permitAll()
+            .anyRequest().authenticated()
     }
 
     @Bean

--- a/src/main/kotlin/com/kotlin/delivery/common/property/JwtProperty.kt
+++ b/src/main/kotlin/com/kotlin/delivery/common/property/JwtProperty.kt
@@ -1,0 +1,8 @@
+package com.kotlin.delivery.common.property
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import org.springframework.boot.context.properties.ConstructorBinding
+
+@ConstructorBinding
+@ConfigurationProperties(prefix = "auth.jwt")
+class JwtProperty(val secretKey: String, val duration: Long)

--- a/src/main/kotlin/com/kotlin/delivery/member/controller/MemberController.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/controller/MemberController.kt
@@ -1,6 +1,8 @@
 package com.kotlin.delivery.member.controller
 
+import com.kotlin.delivery.member.dto.LoginRequest
 import com.kotlin.delivery.member.dto.MemberDTO
+import com.kotlin.delivery.member.service.LoginService
 import com.kotlin.delivery.member.service.MemberService
 import org.springframework.http.HttpStatus
 import org.springframework.web.bind.annotation.PostMapping
@@ -12,9 +14,17 @@ import javax.validation.Valid
 
 @RestController
 @RequestMapping("/members/common")
-class MemberController(private val memberService: MemberService) {
+class MemberController(
+
+    private val memberService: MemberService,
+
+    private val loginService: LoginService
+) {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping("/sign-up")
     fun signUp(@Valid @RequestBody memberDTO: MemberDTO) = memberService.signUp(memberDTO)
+
+    @PostMapping("/login")
+    fun login(@RequestBody req: LoginRequest) = loginService.login(req)
 }

--- a/src/main/kotlin/com/kotlin/delivery/member/dto/LoginRequest.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/dto/LoginRequest.kt
@@ -1,0 +1,8 @@
+package com.kotlin.delivery.member.dto
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+
+data class LoginRequest(val email: String, val password: String) {
+
+    fun toAuthToken() = UsernamePasswordAuthenticationToken(email, password)
+}

--- a/src/main/kotlin/com/kotlin/delivery/member/dto/LoginResponse.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/dto/LoginResponse.kt
@@ -1,0 +1,12 @@
+package com.kotlin.delivery.member.dto
+
+import com.kotlin.delivery.member.entity.Member
+
+interface LoginResponse {
+
+    fun getEmail(): String?
+
+    fun getPassword(): String?
+
+    fun getType(): Member.Type?
+}

--- a/src/main/kotlin/com/kotlin/delivery/member/entity/Member.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/entity/Member.kt
@@ -12,7 +12,7 @@ import javax.persistence.Table
 @Table(name = "members")
 class Member(
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     val email: String,
 
     @Column(nullable = false)

--- a/src/main/kotlin/com/kotlin/delivery/member/repository/MemberRepository.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/repository/MemberRepository.kt
@@ -1,9 +1,12 @@
 package com.kotlin.delivery.member.repository
 
+import com.kotlin.delivery.member.dto.LoginResponse
 import com.kotlin.delivery.member.entity.Member
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<Member, Long> {
+
+    fun findByEmail(email: String): LoginResponse?
 
     fun existsByEmail(email: String): Boolean
 }

--- a/src/main/kotlin/com/kotlin/delivery/member/service/JwtTokenLoginService.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/service/JwtTokenLoginService.kt
@@ -1,0 +1,20 @@
+package com.kotlin.delivery.member.service
+
+import com.kotlin.delivery.auth.jwt.JwtTokenProvider
+import com.kotlin.delivery.member.dto.LoginRequest
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder
+import org.springframework.stereotype.Service
+
+@Service
+class JwtTokenLoginService(
+
+    private val authManagerBuilder: AuthenticationManagerBuilder,
+
+    private val tokenProvider: JwtTokenProvider
+) : LoginService {
+
+    override fun login(req: LoginRequest): String {
+        val authentication = authManagerBuilder.`object`.authenticate(req.toAuthToken())
+        return tokenProvider.generateToken(authentication)
+    }
+}

--- a/src/main/kotlin/com/kotlin/delivery/member/service/LoginService.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/service/LoginService.kt
@@ -1,0 +1,8 @@
+package com.kotlin.delivery.member.service
+
+import com.kotlin.delivery.member.dto.LoginRequest
+
+interface LoginService {
+
+    fun login(req: LoginRequest): String
+}

--- a/src/main/kotlin/com/kotlin/delivery/member/service/MemberDetailsService.kt
+++ b/src/main/kotlin/com/kotlin/delivery/member/service/MemberDetailsService.kt
@@ -1,0 +1,23 @@
+package com.kotlin.delivery.member.service
+
+import com.kotlin.delivery.member.dto.LoginResponse
+import com.kotlin.delivery.member.repository.MemberRepository
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.userdetails.User
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.security.core.userdetails.UsernameNotFoundException
+import org.springframework.stereotype.Service
+
+@Service
+class MemberDetailsService(private val memberRepository: MemberRepository) : UserDetailsService {
+
+    override fun loadUserByUsername(email: String): UserDetails =
+        memberRepository.findByEmail(email)?.let { createUserDetails(it) }
+            ?: throw UsernameNotFoundException("사용자 정보가 일치하지 않습니다. 입력하신 정보를 다시 한 번 확인해주세요.")
+
+    private fun createUserDetails(res: LoginResponse): User {
+        val grantedAuthority = SimpleGrantedAuthority(res.getType().toString())
+        return User(res.getEmail(), res.getPassword(), setOf(grantedAuthority))
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,6 @@ spring:
     jpa:
         database-platform: org.hibernate.dialect.MySQL5InnoDBDialect
         database: mysql
-        show-sql: true
         generate-ddl: true
         hibernate:
           ddl-auto: update
@@ -15,6 +14,7 @@ spring:
         properties:
           hibernate:
             format_sql: true
+            show_sql: true
 
     redis:
         host: localhost
@@ -26,3 +26,8 @@ sms:
         secret: (enter your secret key)
         sender: (enter a representative sender number)
         type: (enter sms type to send)
+
+auth:
+    jwt:
+        secretkey: c3ByaW5nLWJvb3Qtc2VjdXJpdHktand0LXR1dG9yaWFsLWppd29vbi1zcHJpbmctYm9vdC1zZWN1cml0eS1qd3QtdHV0b3JpYWwK
+        duration: 86400000


### PR DESCRIPTION
- 로그인 요청이 들어왔을 때, 요청 받은 파라미터로 `UsernamePasswordAuthenticationToken`을 만든 후 이를 `UserDetailsService`를 구현한 `MemberDetailsService`의 `loadUserByUsername` 메소드를 활용해 DB의 내의 정보를 가져와 비교하는 방식으로 사용자 검증이 이루어집니다.

- `SecurityConfig`에 `.permitAll()` 설정을 추가해서 회원가입과 로그인 end point로 접속했을 때는 아무 검증이 필요없도록 하였고, 나머지는 `.anyRequest().authenticated()`를 일단 적용해 검증이 필요하도록 설정하였습니다.